### PR TITLE
Create and empty OUTDIR every run

### DIFF
--- a/validate_resolvers.sh
+++ b/validate_resolvers.sh
@@ -36,6 +36,8 @@ SUDO=
 $SUDO masscan -iL "$LIST" -p U:53,53 -oG "$SWEEP_OUTFILE" --rate "$PPS_RATE"
 mkdir -p "${TMPDIR}"
 rm -f "${TMPDIR}/{tcp,udp}-up"
+mkdir -p "${OUTDIR}"
+rm -f "${OUTDIR}/*"
 for PROTOCOL in udp tcp
 do
     PROTOCOL_OUTFILE="${TMPDIR}/${PROTOCOL}-${UP_OUTFILE}"


### PR DESCRIPTION
Without this, I was getting "/validate_resolvers.sh: line 48: output/udp-resolvers-confirmed-2018-06-19.lst: No such file or directory" straight from a clone.